### PR TITLE
database: use InterpolateParams

### DIFF
--- a/server/database/database.go
+++ b/server/database/database.go
@@ -25,6 +25,8 @@ func init() {
 
 	c.Collation = "utf8mb4_general_ci"
 
+	c.InterpolateParams = true
+
 	c.ParseTime = true
 
 	if helper.Conf.Database.Protocol == "tcp" {


### PR DESCRIPTION
InterpolateParams reduces the amount of roundtrips to the database by interpolating prepared queries, thus removing the prepare call.

