### PR TITLE
Change message format for simple messages

### DIFF
--- a/server/bot/pipe.go
+++ b/server/bot/pipe.go
@@ -39,7 +39,7 @@ func (b *DiscordBot) Listen() {
 					if !config.Conf.Bot.SimpleMessage {
 						b.Session.ChannelMessageSendEmbed(e.ID, embed)
 					} else {
-						b.Session.ChannelMessageSend(e.ID, fmt.Sprintf("%s: %s", message.ClientName, message.Content))
+						b.Session.ChannelMessageSend(e.ID, fmt.Sprintf("**<%s>** %s", message.ClientName, message.Content))
 					}
 				}
 			}


### PR DESCRIPTION
I feel that messages with the "simple" option should be in the proposed format, as it is a lot easier to read:
>**<Mr.Skullbeef>** This is a message

At the moment this looks like:
>Mr.Skullbeef: This is a message

If you really want the TF2 style of messages with name colon message, you should at the very least make the names have bold characters, i.e:
>**Mr.Skullbeef**: This is a message